### PR TITLE
Grails 2.4 compatibility

### DIFF
--- a/dao-plugin/src/groovy/grails/plugin/dao/DaoUtil.groovy
+++ b/dao-plugin/src/groovy/grails/plugin/dao/DaoUtil.groovy
@@ -3,7 +3,6 @@ package grails.plugin.dao
 import org.codehaus.groovy.grails.commons.GrailsClassUtils
 import org.springframework.transaction.interceptor.TransactionAspectSupport
 import grails.validation.ValidationException
-import org.codehaus.groovy.grails.commons.ApplicationHolder as AH
 import org.codehaus.groovy.grails.plugins.DomainClassGrailsPlugin
 import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
 import org.springframework.dao.DataAccessException


### PR DESCRIPTION
ApplicationHolder was removed since 2.4. And was unused here anyway.

See http://grails.org/doc/2.4.0/guide/upgradingFrom23.html section Static Holder Classes