### PR TITLE
Update JumperDao.groovy

### DIFF
--- a/dao-plugin/grails-app/dao/testing/JumperDao.groovy
+++ b/dao-plugin/grails-app/dao/testing/JumperDao.groovy
@@ -2,7 +2,7 @@ package testing
 import grails.plugin.dao.*
 
 class JumperDao extends GormDaoSupport{ 
-	def domainClass = Jumper
+	Class domainClass = Jumper
 
 }
 


### PR DESCRIPTION
fix compilation error:
dao-plugin/grails-app/dao/testing/JumperDao.groovy: -1: The return type of java.lang.Object getDomainClass() in testing.JumperDao is incompatible with java.lang.Class in grails.plugin.dao.GormDaoSupport